### PR TITLE
CIR-120-Fix-Transactions-issue-error

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -68,16 +68,6 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=response_content.__dict__)
 
 
-@app.post("/test-type-error")
-async def test_type_error():
-    """
-    As RequestValdiationError overrides Exception with 400, this request is used to test
-    the 500 Internal Server Error
-    """
-    response_content = "TypeError"
-    return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content=response_content)
-
-
 @app.delete(
     "/v1/dev/teardown",
     responses={

--- a/tests/unit_tests/test_handlers.py
+++ b/tests/unit_tests/test_handlers.py
@@ -2,8 +2,6 @@ import datetime
 import uuid
 from unittest.mock import patch
 
-import pytest
-
 from app.handlers import (
     delete_ci_v1,
     get_ci_metadata_v1,
@@ -492,18 +490,6 @@ class TestPostCiMetadataV1:
 
         return_value = post_ci_metadata_v1(self.post_data)
         assert return_value == mock_ci_metadata
-
-    def test_handler_returns_none_if_exception_raised(
-        self, mocked_store_ci_schema, mocked_publisher, mocked_post_ci_metadata, mocked_db
-    ):
-        """
-        `delete_ci_metadata_v1` should return `None` if exception is raised at any point during
-        the creation of metadata or schema to firestore and cloud storage
-        """
-        # Configure mocked `post_ci_metadata` to raise a generic exception
-        mocked_post_ci_metadata.side_effect = Exception()
-        with pytest.raises(Exception):
-            post_ci_metadata_v1(self.post_data)
 
 
 @patch("app.handlers.update_ci_metadata_status_to_published")

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -466,15 +466,17 @@ class TestHttpPostCiV1:
         response = client.post(self.url, headers={"ContentType": "application/json"}, json=self.post_data.model_dump())
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_endpoint_returns_500_if_type_error(self, mocked_post_ci_metadata_v1):
+    def test_endpoint_returns_500_if_exception_occurs(self, mocked_post_ci_metadata_v1):
         """
-        Endpoint should return `HTTP_500_INTERNAL_SERVER_ERROR` if a TypeError occurs
+        Endpoint should return `HTTP_500_INTERNAL_SERVER_ERROR` if an exception is raised by the
+        `post_ci_metadata_v1` handler
         """
-        mocked_post_ci_metadata_v1.side_effect = TypeError("Simulated TypeError")
-        response = client.post(
-            "/test-type-error", headers={"Content-Type": "application/json"}, json=self.post_data.model_dump()
-        )
-        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        # Update mocked `post_ci_metadata_v1` to raise a generic exception
+        mocked_post_ci_metadata_v1.side_effect = Exception()
+
+        with pytest.raises(Exception):
+            response = client.post(self.url, headers={"ContentType": "application/json"}, json=self.post_data.model_dump())
+            assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
 
 
 @patch("app.main.put_status_v1")


### PR DESCRIPTION
### Motivation and Context
[CIR-120](https://jira.ons.gov.uk/browse/CIR-120) Bug - Transactions issue, error returns 200. 


### What has changed
* Initially a 500 internal error message using `status.HTTP_500_INTERNAL_SERVER_ERROR` was added in test_main.py but was later removed as fastAPI already handles exceptions(Thank you Jonny :) ) 
* Removed the exception handling for `post_ci_metadata_v1` in `handlers.py`
* Removed  `test_handler_returns_none_if_exception_raised` in `test_handler.py` 
* Added `test_endpoint_returns_500_if_transaction_failed` test in `test_main.py`


### How to test?
* To manually test out the error, comment out any of the environments in `docker-compose.yml` or any line that causes exception in `post_ci_metadata_v1`

