### PR TITLE
CIR-164-Integration-tests-V1-V2

### DIFF
--- a/tests/integration_tests/test_http_get_ci_metadata_v1.py
+++ b/tests/integration_tests/test_http_get_ci_metadata_v1.py
@@ -87,13 +87,12 @@ class TestGetCiMetadataV1:
         assert query_ci_response_json[0]["description"] == setup_payload["description"]
 
     def test_metadata_query_ci_returns_404(self, setup_payload):
-        delete_docs("3456")
         survey_id = setup_payload["survey_id"]
         form_type = setup_payload["form_type"]
         language = setup_payload["language"]
         # sends request to http_query_ci endpoint for data
         query_ci_response = get_ci_metadata_v1(survey_id, form_type, language)
-        query_ci_response.status_code == status.HTTP_404_NOT_FOUND
+        assert query_ci_response.status_code == status.HTTP_404_NOT_FOUND
         query_ci_response = query_ci_response.json()
         expected_response = (
             f"No CI metadata found for: {{'form_type': '{form_type}', 'language': '{language}', 'survey_id': '{survey_id}'}}"
@@ -102,6 +101,12 @@ class TestGetCiMetadataV1:
         assert query_ci_response["status"] == "error"
 
     def test_metadata_query_ci_returns_400(self, setup_payload):
+        """
+        A 400 error can be thrown if arguments/syntactic rules are against the defined endpoint.
+        In this test only two endpoints are passed instead of three.
+        make_iap_request is used instead of get_ci_metadata_v1 here as this function defined in utils.py takes in the
+        three required parameters. Using make_iap_request can enable us to throw 400 error.
+        """
         survey_id = setup_payload["survey_id"]
         form_type = setup_payload["form_type"]
         querystring = urlencode({"survey_id": survey_id, "form_type": form_type})

--- a/tests/integration_tests/test_http_get_ci_metadata_v2.py
+++ b/tests/integration_tests/test_http_get_ci_metadata_v2.py
@@ -140,7 +140,7 @@ class TestGetCiMetadataV2:
         }
         # sends request to http_query_ci endpoint for data
         query_ci_response = get_ci_metadata_v2(get_ci_metadata_v2_payload)
-        query_ci_response.status_code == status.HTTP_404_NOT_FOUND
+        assert query_ci_response.status_code == status.HTTP_404_NOT_FOUND
         query_ci_response = query_ci_response.json()
         expected_response = f"No CI metadata found for: {get_ci_metadata_v2_payload}"
         assert query_ci_response["message"] == expected_response


### PR DESCRIPTION
### Motivation and Context
[CIR-164](https://jira.ons.gov.uk/browse/CIR-164])Integration tests - V1 & V2 Metadata

### What has changed
* Added new tests which checks 400 and 404 status code for the V1 metadata endpoint.
* Added new test which checks 404 status code for the V2 metadata endpoint(Note- 400 status code cannot be tested because the model created for `get_ci_metadata_v2` request query params, takes in optional params, which causes the fastapi to return a 404 error even if the incorrect parameters are given )

### How to test?
`make integration-tests`