### PR TITLE
CIR-163 Add Unauthenticated Integration tests

### DIFF
--- a/tests/integration_tests/test_http_delete_ci_v1.py
+++ b/tests/integration_tests/test_http_delete_ci_v1.py
@@ -4,10 +4,7 @@ from urllib.parse import urlencode
 from fastapi import status
 
 from app.events.subscriber import Subscriber
-from tests.integration_tests.utils import (
-    make_iap_request,
-    make_iap_request_with_unauthoried_id,
-)
+from tests.integration_tests.utils import make_iap_request
 
 
 class TestDeleteCiV1:
@@ -67,5 +64,5 @@ class TestDeleteCiV1:
         """
         survey_id = setup_payload["survey_id"]
         querystring = urlencode({"survey_id": survey_id})
-        response = make_iap_request_with_unauthoried_id("DELETE", f"{self.base_url}?{querystring}")
+        response = make_iap_request("DELETE", f"{self.base_url}?{querystring}", unauthenticated=True)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/integration_tests/test_http_get_ci_metadata_v1.py
+++ b/tests/integration_tests/test_http_get_ci_metadata_v1.py
@@ -3,10 +3,7 @@ from urllib.parse import urlencode
 from fastapi import status
 
 from app.events.subscriber import Subscriber
-from tests.integration_tests.utils import (
-    make_iap_request,
-    make_iap_request_with_unauthoried_id,
-)
+from tests.integration_tests.utils import make_iap_request
 
 
 class TestGetCiMetadataV1:
@@ -136,5 +133,6 @@ class TestGetCiMetadataV1:
         form_type = setup_payload["form_type"]
         language = setup_payload["language"]
         querystring = urlencode({"survey_id": survey_id, "form_type": form_type, language: "language"})
-        response = make_iap_request_with_unauthoried_id("GET", f"{self.base_url}?{querystring}")
+        response = make_iap_request("GET", f"{self.base_url}?{querystring}", unauthenticated=True)
+        print(response)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/integration_tests/test_http_get_ci_metadata_v2.py
+++ b/tests/integration_tests/test_http_get_ci_metadata_v2.py
@@ -3,10 +3,7 @@ from urllib.parse import urlencode
 from fastapi import status
 
 from app.events.subscriber import Subscriber
-from tests.integration_tests.utils import (
-    make_iap_request,
-    make_iap_request_with_unauthoried_id,
-)
+from tests.integration_tests.utils import make_iap_request
 
 
 class TestGetCiMetadataV2:
@@ -118,5 +115,5 @@ class TestGetCiMetadataV2:
             "survey_id": setup_payload["survey_id"],
         }
         querystring = urlencode(get_ci_metadata_v2_payload)
-        response = make_iap_request_with_unauthoried_id("GET", f"{self.base_url}?{querystring}")
+        response = make_iap_request("GET", f"{self.base_url}?{querystring}", unauthenticated=True)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/integration_tests/test_http_get_ci_schema_v1.py
+++ b/tests/integration_tests/test_http_get_ci_schema_v1.py
@@ -5,10 +5,7 @@ from fastapi import status
 
 from app.events.subscriber import Subscriber
 from app.models.requests import GetCiSchemaV1Params
-from tests.integration_tests.utils import (
-    make_iap_request,
-    make_iap_request_with_unauthoried_id,
-)
+from tests.integration_tests.utils import make_iap_request
 
 
 class TestHttpGetCiSchemaV1:
@@ -86,5 +83,5 @@ class TestHttpGetCiSchemaV1:
 
         querystring = urlencode(asdict(query_params))
 
-        response = make_iap_request_with_unauthoried_id("GET", f"{self.url}?{querystring}")
+        response = make_iap_request("GET", f"{self.url}?{querystring}", unauthenticated=True)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/integration_tests/test_http_get_ci_schema_v2.py
+++ b/tests/integration_tests/test_http_get_ci_schema_v2.py
@@ -5,10 +5,7 @@ from fastapi import status
 
 from app.events.subscriber import Subscriber
 from app.models.requests import GetCiSchemaV2Params
-from tests.integration_tests.utils import (
-    make_iap_request,
-    make_iap_request_with_unauthoried_id,
-)
+from tests.integration_tests.utils import make_iap_request
 
 
 class TestHttpGetCiSchemaV2:
@@ -81,5 +78,6 @@ class TestHttpGetCiSchemaV2:
         query_params = GetCiSchemaV2Params(guid="30134e70-c28c-4dcc-b0b0-e403b2df0b24")
         querystring = urlencode(asdict(query_params))
 
-        response = make_iap_request_with_unauthoried_id("GET", f"{self.url}?{querystring}")
+        response = make_iap_request("GET", f"{self.url}?{querystring}", unauthenticated=True)
+        print(response)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/integration_tests/test_http_post_ci_metadata_v1.py
+++ b/tests/integration_tests/test_http_post_ci_metadata_v1.py
@@ -5,10 +5,7 @@ from fastapi import status
 
 from app.events.subscriber import Subscriber
 from app.models.responses import CiMetadata, CiStatus
-from tests.integration_tests.utils import (
-    make_iap_request,
-    make_iap_request_with_unauthoried_id,
-)
+from tests.integration_tests.utils import make_iap_request
 
 
 class TestPostCiV1:
@@ -288,6 +285,6 @@ class TestPostCiV1:
         requested with an unauthorized token.
         """
         payload = setup_payload
-        ci_response = make_iap_request_with_unauthoried_id("POST", f"{self.post_url}", json=payload)
+        ci_response = make_iap_request("POST", f"{self.post_url}", json=payload, unauthenticated=True)
 
         assert ci_response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/integration_tests/test_http_put_status_v1.py
+++ b/tests/integration_tests/test_http_put_status_v1.py
@@ -3,10 +3,7 @@ from urllib.parse import urlencode
 from fastapi import status
 
 from app.events.subscriber import Subscriber
-from tests.integration_tests.utils import (
-    make_iap_request,
-    make_iap_request_with_unauthoried_id,
-)
+from tests.integration_tests.utils import make_iap_request
 
 
 class TestPutStatusV1:
@@ -108,5 +105,5 @@ class TestPutStatusV1:
         ci_id = "401"
         querystring = urlencode({"guid": ci_id})
         # sends request to http_put_status
-        ci_update = make_iap_request_with_unauthoried_id("PUT", f"{self.base_url}?{querystring}")
+        ci_update = make_iap_request("PUT", f"{self.base_url}?{querystring}", unauthenticated=True)
         assert ci_update.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
[CIR-163](https://jira.ons.gov.uk/browse/CIR-163) Integration tests - Adding unauthenticated integration tests 

### What has changed
* Added new function in `make_iap_request_with_unauthoried_id` in `utils.py` that requests using unauthorized `OAUTH_CLIENT_ID` to show an unauthenticated error.
* Added the `HTTP_401_UNAUTHORIZED` test for all the endpoints

### How to test?
`make integration-tests`

