### PR TITLE
CIR-177 Fixing FIRESTORE_DB_NAME

### DIFF
--- a/cloudbuild-prod.yaml
+++ b/cloudbuild-prod.yaml
@@ -1,8 +1,4 @@
 steps:
-  - name: python:3.11
-    id: "Upgrade pip"
-    entrypoint: "python"
-    args: ["-m", "pip", "install", "--upgrade", "pip", "--user"]
   - name: docker
     id: "Build and push docker image"
     entrypoint: sh


### PR DESCRIPTION
### Motivation and Context
This PR fixes the issue with the docker container which Mike found while reviewing [CIR-177](https://jira.ons.gov.uk/browse/CIR-177)

### What has changed
FIRESTORE_DB_NAME is set to `(default)`

### How to test?
Run `docker-compose up` 