### PR TITLE
added container vulnerability checking steps to cloudbuild-dev

### DIFF
--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -47,7 +47,7 @@ steps:
 
   - name: "gcr.io/cloud-builders/gcloud"
     id: "Show image vulnerabilities (ons-sds-dev only)"
-    entrypoint: sh
+    entrypoint: bash
     args:
       - "-c"
       - |
@@ -61,7 +61,7 @@ steps:
 
   - name: "gcr.io/cloud-builders/gcloud"
     id: "Check for critical vulnerabilities (ons-sds-dev only)"
-    entrypoint: sh
+    entrypoint: bash
     args:
       - "-c"
       - |


### PR DESCRIPTION
### Motivation and Context
https://jira.ons.gov.uk/browse/SDSS-287

### What has changed
* `cloudbuild-dev.yaml` updated to run vulnerability scanning steps. These steps are only run when on `ons-sds-dev` project. This will ensure the scanning is only run on merge to main triggers

### How to test?
* Check that the vulnerability checking steps do not do anything when run against `ons-sds-sandbox-01` (PR trigger)
* Check that the vulnerability checking steps do check the container when run against `ons-sds-dev` (merge to main trigger)