### PR TITLE
Change tag to use github.ref_name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build container
-        run: docker build -t onsdigital/cir:$GITHUB_REF .
+        run: docker build -t onsdigital/cir:${{github.ref_name}} .
       - name: Push built container to dockerhub
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-          echo "Pushing with tag $GITHUB_REF"
-          docker push onsdigital/cir:$GITHUB_REF
+          echo "Pushing with tag ${{github.ref_name}}"
+          docker push onsdigital/cir:${{github.ref_name}}


### PR DESCRIPTION
### Motivation and Context
Fix the issue of invalid tag in the workflow to publish new released app to dockerhub

### What has changed
Tag is changed from using fully-formatted one to short-formed one

### How to test?
Try rerun the workflow after merging this PR

### Links
https://github.com/ONSdigital/eq-cir-fastapi/actions/runs/7475249530

### Screenshots (if appropriate):