### PR TITLE
In cloudbuild-prod pipeline, move image to new ci env

### DIFF
--- a/cloudbuild-prod.yaml
+++ b/cloudbuild-prod.yaml
@@ -5,9 +5,9 @@ steps:
     args:
       - "-c"
       - |
-        docker build -t "europe-west2-docker.pkg.dev/ons-sds-dns/cir/${PROJECT_ID}:latest" -t "europe-west2-docker.pkg.dev/ons-sds-dns/cir/${PROJECT_ID}:${TAG_NAME}" .
-        docker push "europe-west2-docker.pkg.dev/ons-sds-dns/cir/${PROJECT_ID}:latest"
-        docker push "europe-west2-docker.pkg.dev/ons-sds-dns/cir/${PROJECT_ID}:${TAG_NAME}"
+        docker build -t "europe-west2-docker.pkg.dev/ons-sds-ci/cir-perm/${PROJECT_ID}:latest" -t "europe-west2-docker.pkg.dev/ons-sds-ci/cir-perm/${PROJECT_ID}:${TAG_NAME}" .
+        docker push "europe-west2-docker.pkg.dev/ons-sds-ci/cir-perm/${PROJECT_ID}:latest"
+        docker push "europe-west2-docker.pkg.dev/ons-sds-ci/cir-perm/${PROJECT_ID}:${TAG_NAME}"
 
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     id: "Deploy docker image to cloud run"
@@ -18,7 +18,7 @@ steps:
         "deploy",
         "cir",
         "--image",
-        "europe-west2-docker.pkg.dev/ons-sds-dns/cir/${PROJECT_ID}:latest",
+        "europe-west2-docker.pkg.dev/ons-sds-ci/cir-perm/${PROJECT_ID}:latest",
         "--region",
         "europe-west2",
         "--allow-unauthenticated",
@@ -33,5 +33,5 @@ options:
 
 # Store images in Google Artifact Registry
 images:
-  - europe-west2-docker.pkg.dev/ons-sds-dns/cir/${PROJECT_ID}:${TAG_NAME}
-  - europe-west2-docker.pkg.dev/ons-sds-dns/cir/${PROJECT_ID}:latest
+  - europe-west2-docker.pkg.dev/ons-sds-ci/cir-perm/${PROJECT_ID}:${TAG_NAME}
+  - europe-west2-docker.pkg.dev/ons-sds-ci/cir-perm/${PROJECT_ID}:latest


### PR DESCRIPTION
### Motivation and Context
ons-sds-ci is to replace ons-sds-dns in storing images for permanent environments

### What has changed
Build and pull image from ons-sds-ci for cloudbuild-prod pipeline

### How to test?
Pass pipeline

### Links
https://jira.ons.gov.uk/browse/SDSS-898

### Screenshots (if appropriate):