### PR TITLE
Specify current datetime timezone to be UTC+0

### DIFF
--- a/.coveragerc_unit
+++ b/.coveragerc_unit
@@ -2,3 +2,4 @@
 omit =
     app/repositories/*
     app/routers/ci_router.py
+    app/routers/validator_router.py

--- a/.coveragerc_unit_deprecated
+++ b/.coveragerc_unit_deprecated
@@ -2,3 +2,4 @@
 omit =
     app/repositories/*
     app/routers/ci_router_restful.py
+    app/routers/validator_router_restful.py

--- a/app/services/datetime_service.py
+++ b/app/services/datetime_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 
 class DatetimeService:
@@ -7,4 +7,4 @@ class DatetimeService:
         """
         Gets current date and time in UTC timezone.
         """
-        return datetime.now(tz=timezone.utc)
+        return datetime.now(tz=UTC)

--- a/app/services/datetime_service.py
+++ b/app/services/datetime_service.py
@@ -1,10 +1,10 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class DatetimeService:
     @staticmethod
     def get_current_date_and_time() -> datetime:
         """
-        Gets current date and time. Wrapper for datetime.now() function to make it easier to mock for tests.
+        Gets current date and time in UTC timezone.
         """
-        return datetime.now()
+        return datetime.now(tz=timezone.utc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cir"
-version = "1.0.1"
+version = "1.0.2"
 description = "Collection Instrument Registry"
 requires-python = ">=3.13,<3.14"
 dependencies = [

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -18,11 +18,14 @@ settings = Settings()
 
 
 @pytest.fixture(autouse=True)
-def mock_datetime(mocker):
-    mocker.patch(
-        "app.services.datetime_service.DatetimeService.get_current_date_and_time",
-        return_value=mock_publish_date,
-    )
+def mock_datetime(request, mocker):
+    if "use_real_datetime" in request.keywords:
+        pass # Bypass mocking datetime
+    else:
+        mocker.patch(
+            "app.services.datetime_service.DatetimeService.get_current_date_and_time",
+            return_value=mock_publish_date,
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit_tests/functions/test_datetime_service.py
+++ b/tests/unit_tests/functions/test_datetime_service.py
@@ -1,0 +1,17 @@
+import datetime
+
+import pytest
+
+from app.services.datetime_service import DatetimeService
+
+
+@pytest.mark.use_real_datetime
+def test_get_current_date_and_time():
+    """
+    Test that the get_current_date_and_time function returns a datetime object with UTC timezone.
+    """
+    dt = DatetimeService.get_current_date_and_time()
+
+    assert dt.tzinfo is not None
+    assert dt.tzinfo.utcoffset(dt) == datetime.timedelta(0)
+    assert dt.tzname() in {"UTC", "UTC+00:00"}

--- a/uv.lock
+++ b/uv.lock
@@ -145,7 +145,7 @@ wheels = [
 
 [[package]]
 name = "cir"
-version = "1.0.1"
+version = "1.0.2"
 source = { virtual = "." }
 dependencies = [
     { name = "coverage" },


### PR DESCRIPTION
### Motivation and Context
To help align the timezone used in products that integrate with CIR

### What has changed
Specified the timezone in CIR is UTC+0
Add test to validate the datetime

### How to test?
Passed unit tests
Passed Integration tests

### Links
https://officefornationalstatistics.atlassian.net/browse/DFTS-1683

### Screenshots (if appropriate):